### PR TITLE
v1.0.1

### DIFF
--- a/Advanced_DHCP_Content.asp
+++ b/Advanced_DHCP_Content.asp
@@ -288,7 +288,7 @@ function reload(){
 
 function update_status(){
 	$.ajax({
-		url: '/ext/yazdhcp/detect_update.js',
+		url: '/ext/YazDHCP/detect_update.js',
 		dataType: 'script',
 		timeout: 3000,
 		error: function(xhr){

--- a/Advanced_DHCP_Content.asp
+++ b/Advanced_DHCP_Content.asp
@@ -104,9 +104,8 @@ function SelectedFile(){
 	var fileList = event.target.files;
 	var filename = fileList[0].name.split('.')[0];
 	var fileext = fileList[0].name.substring(fileList[0].name.indexOf('.')+1);
-	
-	if(filename != "DHCP_clients" && fileext != "csv" && fileext != "htm" && fileext != "csv.htm"){
-		alert("Filename must be DHCP_clients\nAllowed extensions are .csv .htm .csv.htm");
+	if(filename != "DHCP_clients" && fileext != "csv"){
+		alert("Filename must be DHCP_clients.csv");
 		$("#fileImportDHCPClients").val('');
 	}
 	else{
@@ -146,6 +145,7 @@ function ParseCSVData(data){
 	dhcp_hostnames_array = [];
 	manually_dhcp_hosts_array = [];
 	
+	var csvContent = "MAC,IP,HOSTNAME,DNS\n";
 	var settingslength = 0;
 	for(var i = 0; i < data.length; i++){
 		if(data[i].DNS.length > 0 && data[i].HOSTNAME.length >= 0){
@@ -157,7 +157,11 @@ function ParseCSVData(data){
 		else{
 			settingslength+=(data[i].MAC+">"+data[i].IP.split(".")[3]+">").length;
 		}
+		var dataString = data[i].MAC+","+data[i].IP+","+data[i].HOSTNAME+","+data[i].DNS;
+		csvContent += i < data.length-1 ? dataString + '\n' : dataString;
 	}
+	
+	document.getElementById("aExport").href="data:text/csv;charset=utf-8," + encodeURIComponent(csvContent);
 	
 	var averagesettinglength = Math.round(settingslength / data.length);
 	maxnumrows = Math.round(apimaxlength / averagesettinglength);
@@ -1135,7 +1139,7 @@ function parse_vpnc_dev_policy_list(_oriNvram){
 <tr>
 <th width="20%">Export</th>
 <td>
-<a href="/ext/YazDHCP/DHCP_clients.htm" download="DHCP_clients.csv"><input type="button" value="Export to CSV" class="button_gen" name="btnExport"></a>
+<a id="aExport" href="" download="DHCP_clients.csv"><input type="button" value="Export to CSV" class="button_gen" name="btnExport"></a>
 </td>
 </tr>
 <tr>

--- a/Advanced_DHCP_Content.asp
+++ b/Advanced_DHCP_Content.asp
@@ -318,14 +318,14 @@ function update_status(){
 
 function CheckUpdate(){
 	showhide("btnChkUpdate", false);
-	document.formScriptActions.action_script.value="start_yazdhcpcheckupdate"
+	document.formScriptActions.action_script.value="start_YazDHCPcheckupdate"
 	document.formScriptActions.submit();
 	document.getElementById("imgChkUpdate").style.display = "";
 	setTimeout(update_status, 2000);
 }
 
 function DoUpdate(){
-	var action_script_tmp = "start_yazdhcpdoupdate";
+	var action_script_tmp = "start_YazDHCPdoupdate";
 	document.form.action_script.value = action_script_tmp;
 	var restart_time = 10;
 	document.form.action_wait.value = restart_time;

--- a/Advanced_DHCP_Content.asp
+++ b/Advanced_DHCP_Content.asp
@@ -64,6 +64,9 @@ var dhcp_staticlist_array = [];
 var manually_dhcp_list_array = [];
 var manually_dhcp_list_array_ori = [];
 
+var dhcp_hostnames_array = [];
+var manually_dhcp_hosts_array = [];
+
 if(pptpd_support){
 	var pptpd_clients = '<% nvram_get("pptpd_clients"); %>';
 	var pptpd_clients_subnet = pptpd_clients.split(".")[0]+"." + pptpd_clients.split(".")[1]+"." + pptpd_clients.split(".")[2]+".";
@@ -79,9 +82,6 @@ var pool_start_end = parseInt(pool_start.split(".")[3]);
 var pool_end_end = parseInt(pool_end.split(".")[3]);
 
 var static_enable = '<% nvram_get("dhcp_static_x"); %>';
-
-var dhcp_hostnames_array = [];
-var manually_dhcp_hosts_array = [];
 
 var lan_domain_ori = '<% nvram_get("lan_domain"); %>';
 var dhcp_gateway_ori = '<% nvram_get("dhcp_gateway_x"); %>';
@@ -100,6 +100,139 @@ var backup_name = "";
 var sortfield, sortdir;
 var sorted_array = [];
 
+function SelectedFile(){
+	var fileList = event.target.files;
+	if(fileList[0].name != "DHCP_clients.csv"){
+		alert("File must be named DHCP_clients.csv");
+		$("#fileImportDHCPClients").val('');
+	}
+	else{
+		var fileReader = new FileReader();
+		fileReader.addEventListener('load',LoadedFile,false);
+		fileReader.readAsText(fileList[0]);
+	}
+}
+
+function LoadedFile(){
+	var dataResult = [];
+	var fileResult = event.target.result.split('\n');
+	fileResult.shift();
+	for(var i=0; i < fileResult.length; i++){
+		var obj = {};
+		if(fileResult[i] == ""){
+			continue;
+		}
+		var splitstring = fileResult[i].split(',');
+		obj["MAC"] = splitstring[0].replace(/[\x00-\x1F\x7F-\x9F]/g, "");
+		obj["IP"] = splitstring[1].replace(/[\x00-\x1F\x7F-\x9F]/g, "");
+		obj["HOSTNAME"] = splitstring[2].replace(/[\x00-\x1F\x7F-\x9F]/g, "");
+		obj["DNS"] = splitstring[3].replace(/[\x00-\x1F\x7F-\x9F]/g, "");
+		dataResult.push(obj);
+	}
+	
+	ParseCSVData(dataResult);
+	PageSetup();
+	alert("CSV import complete.\nPlease check the Manual Assignment table.\nTo save the imported data, click Apply at the bottom of the page.");
+	$("#fileImportDHCPClients").val('');
+}
+
+function ParseCSVData(data){
+	dhcp_staticlist_array = [];
+	manually_dhcp_list_array = [];
+	manually_dhcp_list_array_ori = [];
+	dhcp_hostnames_array = [];
+	manually_dhcp_hosts_array = [];
+	
+	var settingslength = 0;
+	for(var i = 0; i < data.length; i++){
+		if(data[i].DNS.length > 0 && data[i].HOSTNAME.length >= 0){
+			settingslength+=(data[i].MAC+">"+data[i].IP.split(".")[3]+">"+data[i].HOSTNAME+">"+data[i].DNS+">").length;
+		}
+		else if(data[i].DNS.length == 0 && data[i].HOSTNAME.length > 0){
+			settingslength+=(data[i].MAC+">"+data[i].IP.split(".")[3]+">"+data[i].HOSTNAME+">").length;
+		}
+		else{
+			settingslength+=(data[i].MAC+">"+data[i].IP.split(".")[3]+">").length;
+		}
+	}
+	
+	var averagesettinglength = Math.round(settingslength / data.length);
+	maxnumrows = Math.round(apimaxlength / averagesettinglength);
+	
+	if(maxnumrows > 253){
+		maxnumrows = 253;
+	}
+	
+	document.getElementById("GWStatic").innerHTML = "Manually Assigned IP addresses in the DHCP scope (Max Limit: " + maxnumrows + ")";
+	
+	dhcp_hostnames_array = data.map(function(obj) {
+		return {
+			MAC: obj.MAC,
+			HOSTNAME: obj.HOSTNAME
+		}
+	});
+	
+	for(var i = 0; i < dhcp_hostnames_array.length; i++){
+		var item_para = {"hostname" : dhcp_hostnames_array[i].HOSTNAME};
+		manually_dhcp_hosts_array[dhcp_hostnames_array[i].MAC] = item_para;
+	}
+	
+	dhcp_staticlist_array = data.map(function(obj) {
+		return {
+			MAC: obj.MAC,
+			IP: obj.IP,
+			DNS: obj.DNS
+		}
+	});
+	
+	for(var i = 0; i < dhcp_staticlist_array.length; i++){
+		var item_para = {
+			"mac" : dhcp_staticlist_array[i].MAC.toUpperCase(),
+			"dns" : dhcp_staticlist_array[i].DNS,
+			"hostname" : (manually_dhcp_hosts_array[dhcp_staticlist_array[i].MAC] == undefined) ? "" : manually_dhcp_hosts_array[dhcp_staticlist_array[i].MAC].hostname,
+			"ip" : dhcp_staticlist_array[i].IP
+		};
+		manually_dhcp_list_array[dhcp_staticlist_array[i].IP] = item_para;
+		manually_dhcp_list_array_ori[dhcp_staticlist_array[i].IP] = item_para;
+	}
+}
+
+function PageSetup(){
+	showtext(document.getElementById("LANIP"), '<% nvram_get("lan_ipaddr"); %>');
+	if((inet_network(document.form.lan_ipaddr.value) >= inet_network(document.form.dhcp_start.value)) && (inet_network(document.form.lan_ipaddr.value) <= inet_network(document.form.dhcp_end.value))){
+			document.getElementById('router_in_pool').style.display="";
+	}
+	else if(dhcp_staticlist_array.length > 0){
+		for(var i = 0; i < dhcp_staticlist_array.length; i++){
+			var static_ip = dhcp_staticlist_array[i].IP;
+			if(static_ip == document.form.lan_ipaddr.value){
+				document.getElementById('router_in_pool').style.display="";
+			}
+		}
+	}
+	
+	if(((sortfield = cookie.get('dhcp_sortcol')) != null) && ((sortdir = cookie.get('dhcp_sortmet')) != null)){
+		sortfield = parseInt(sortfield);
+		sortdir = parseInt(sortdir) * -1;
+	}
+	else{
+		sortfield = 1;
+		sortdir = -1;
+	}
+	sortlist(sortfield);
+	
+	setTimeout(showdhcp_staticlist, 100);
+	setTimeout("showDropdownClientList('setClientIP', 'mac>ip', 'all', 'ClientList_Block_PC', 'pull_arrow', 'all');", 1000);
+	
+	if(pptpd_support){
+		var chk_vpn = check_vpn();
+		if(chk_vpn == true){
+			document.getElementById("VPN_conflict").style.display = "";
+			document.getElementById("VPN_conflict_span").innerHTML = "* In conflict with the VPN server settings:" + pptpd_clients;
+		}
+	}
+}
+
 function initial(){
 	show_menu();
 	document.getElementById("GWStatic").innerHTML = "Manually Assigned IP addresses in the DHCP scope (Max Limit: )" + maxnumrows;
@@ -111,94 +244,9 @@ function initial(){
 	
 	d3.csv("/ext/YazDHCP/DHCP_clients.htm").then(function(data){
 		if(data.length > 0){
-			
-			var settingslength = 0;
-			for(var i = 0; i < data.length; i++){
-				if(data[i].DNS.length > 0 && data[i].HOSTNAME.length >= 0){
-					settingslength+=(data[i].MAC+">"+data[i].IP.split(".")[3]+">"+data[i].HOSTNAME+">"+data[i].DNS+">").length;
-				}
-				else if(data[i].DNS.length == 0 && data[i].HOSTNAME.length > 0){
-					settingslength+=(data[i].MAC+">"+data[i].IP.split(".")[3]+">"+data[i].HOSTNAME+">").length;
-				}
-				else{
-					settingslength+=(data[i].MAC+">"+data[i].IP.split(".")[3]+">").length;
-				}
-			}
-			
-			var averagesettinglength = Math.round(settingslength / data.length);
-			maxnumrows = Math.round(apimaxlength / averagesettinglength);
-			
-			if(maxnumrows > 253){
-				maxnumrows = 253;
-			}
-			
-			document.getElementById("GWStatic").innerHTML = "Manually Assigned IP addresses in the DHCP scope (Max Limit: " + maxnumrows + ")";
-			
-			dhcp_hostnames_array = data.map(function(obj) {
-				return {
-					MAC: obj.MAC,
-					HOSTNAME: obj.HOSTNAME
-				}
-			});
-			
-			for(var i = 0; i < dhcp_hostnames_array.length; i++){
-				var item_para = {"hostname" : dhcp_hostnames_array[i].HOSTNAME};
-				manually_dhcp_hosts_array[dhcp_hostnames_array[i].MAC] = item_para;
-			}
-			
-			dhcp_staticlist_array = data.map(function(obj) {
-				return {
-					MAC: obj.MAC,
-					IP: obj.IP,
-					DNS: obj.DNS
-				}
-			});
-			
-			for(var i = 0; i < dhcp_staticlist_array.length; i++){
-				var item_para = {
-					"mac" : dhcp_staticlist_array[i].MAC.toUpperCase(),
-					"dns" : dhcp_staticlist_array[i].DNS,
-					"hostname" : (manually_dhcp_hosts_array[dhcp_staticlist_array[i].MAC] == undefined) ? "" : manually_dhcp_hosts_array[dhcp_staticlist_array[i].MAC].hostname,
-					"ip" : dhcp_staticlist_array[i].IP
-				};
-				manually_dhcp_list_array[dhcp_staticlist_array[i].IP] = item_para;
-				manually_dhcp_list_array_ori[dhcp_staticlist_array[i].IP] = item_para;
-			}
+			ParseCSVData(data);
 		}
-		
-		showtext(document.getElementById("LANIP"), '<% nvram_get("lan_ipaddr"); %>');
-		if((inet_network(document.form.lan_ipaddr.value) >= inet_network(document.form.dhcp_start.value)) && (inet_network(document.form.lan_ipaddr.value) <= inet_network(document.form.dhcp_end.value))){
-				document.getElementById('router_in_pool').style.display="";
-		}
-		else if(dhcp_staticlist_array.length > 0){
-			for(var i = 0; i < dhcp_staticlist_array.length; i++){
-				var static_ip = dhcp_staticlist_array[i].IP;
-				if(static_ip == document.form.lan_ipaddr.value){
-					document.getElementById('router_in_pool').style.display="";
-				}
-			}
-		}
-		
-		if(((sortfield = cookie.get('dhcp_sortcol')) != null) && ((sortdir = cookie.get('dhcp_sortmet')) != null)){
-			sortfield = parseInt(sortfield);
-			sortdir = parseInt(sortdir) * -1;
-		}
-		else{
-			sortfield = 1;
-			sortdir = -1;
-		}
-		sortlist(sortfield);
-		
-		setTimeout(showdhcp_staticlist, 100);
-		setTimeout("showDropdownClientList('setClientIP', 'mac>ip', 'all', 'ClientList_Block_PC', 'pull_arrow', 'all');", 1000);
-		
-		if(pptpd_support){
-			var chk_vpn = check_vpn();
-			if(chk_vpn == true){
-				document.getElementById("VPN_conflict").style.display = "";
-				document.getElementById("VPN_conflict_span").innerHTML = "* In conflict with the VPN server settings:" + pptpd_clients;
-			}
-		}
+		PageSetup();
 	});
 	
 	if(yadns_support){
@@ -1081,10 +1129,20 @@ function parse_vpnc_dev_policy_list(_oriNvram){
 &nbsp;&nbsp;&nbsp;
 </td>
 </tr>
+<tr>
+<th width="20%">Export</th>
+<td>
+<a href="/ext/YazDHCP/DHCP_clients.htm" download="DHCP_clients.csv"><input type="button" value="Export to CSV" class="button_gen" name="btnExport"></a>
+</td>
+</tr>
+<tr>
+<th width="20%">Import</th>
+<td>
+<input type="file" name="fileImportDHCPClients" id="fileImportDHCPClients" accept=".csv" onchange="SelectedFile();" >
+</td>
+</tr>
 </table>
 <div style="line-height:10px;">&nbsp;</div>
-
-
 <table width="100%" border="1" align="center" cellpadding="4" cellspacing="0" bordercolor="#6b8fa3" class="FormTable">
 
 <thead><tr><td colspan="2">Basic Config</td></tr></thead>
@@ -1221,7 +1279,7 @@ function parse_vpnc_dev_policy_list(_oriNvram){
 <input type="text" class="input_15_table" maxlength="15" name="dhcp_dnsip_x_0" onkeypress="return validator.isIPAddr(this,event)" autocorrect="off" autocapitalize="off">
 </td>
 <td width="23%">
-<input type="text" class="input_15_table" maxlenght="30" onkeypress="return validator.isString(this, event);" name="dhcp_staticname_x_0" autocorrect="off" autocapitalize="off">
+<input type="text" class="input_15_table" maxlength="30" onkeypress="return validator.isString(this, event);" name="dhcp_staticname_x_0" autocorrect="off" autocapitalize="off">
 </td>
 <td width="7%">
 <div>

--- a/Advanced_DHCP_Content.asp
+++ b/Advanced_DHCP_Content.asp
@@ -102,8 +102,11 @@ var sorted_array = [];
 
 function SelectedFile(){
 	var fileList = event.target.files;
-	if(fileList[0].name != "DHCP_clients.csv"){
-		alert("File must be named DHCP_clients.csv");
+	var filename = fileList[0].name.split('.')[0];
+	var fileext = fileList[0].name.substring(fileList[0].name.indexOf('.')+1);
+	
+	if(filename != "DHCP_clients" && fileext != "csv" && fileext != "htm" && fileext != "csv.htm"){
+		alert("Filename must be DHCP_clients\nAllowed extensions are .csv .htm .csv.htm");
 		$("#fileImportDHCPClients").val('');
 	}
 	else{

--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 [![Codacy Badge](https://app.codacy.com/project/badge/Grade/1f193c7b92a34b60bc1ef9a647f04908)](https://www.codacy.com/gh/jackyaz/YazDHCP/dashboard?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=jackyaz/YazDHCP&amp;utm_campaign=Badge_Grade)
 [![Build Status](https://travis-ci.com/jackyaz/YazDHCP.svg?branch=master)](https://travis-ci.com/jackyaz/YazDHCP)
 
-## v1.0.0
-### Updated on 2021-01-12
+## v1.0.1
+### Updated on 2021-01-15
 ## About
 Feature expansion of DHCP assignments using AsusWRT-Merlin's [Addons API](https://github.com/RMerl/asuswrt-merlin.ng/wiki/Addons-API) to read and write DHCP assignments, increasing the limit on the number of reservations.
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Build Status](https://travis-ci.com/jackyaz/YazDHCP.svg?branch=master)](https://travis-ci.com/jackyaz/YazDHCP)
 
 ## v1.0.1
-### Updated on 2021-01-15
+### Updated on 2021-01-19
 ## About
 Feature expansion of DHCP assignments using AsusWRT-Merlin's [Addons API](https://github.com/RMerl/asuswrt-merlin.ng/wiki/Addons-API) to read and write DHCP assignments, increasing the limit on the number of reservations.
 

--- a/YazDHCP.sh
+++ b/YazDHCP.sh
@@ -15,8 +15,8 @@
 
 ### Start of script variables ###
 readonly SCRIPT_NAME="YazDHCP"
-readonly SCRIPT_VERSION="v1.0.0"
-readonly SCRIPT_BRANCH="master"
+readonly SCRIPT_VERSION="v1.0.1"
+readonly SCRIPT_BRANCH="develop"
 readonly SCRIPT_REPO="https://raw.githubusercontent.com/jackyaz/$SCRIPT_NAME/$SCRIPT_BRANCH"
 readonly SCRIPT_DIR="/jffs/addons/$SCRIPT_NAME.d"
 readonly SCRIPT_CONF="$SCRIPT_DIR/DHCP_clients"

--- a/YazDHCP.sh
+++ b/YazDHCP.sh
@@ -15,8 +15,8 @@
 
 ### Start of script variables ###
 readonly SCRIPT_NAME="YazDHCP"
-readonly SCRIPT_VERSION="v1.0.0"
-SCRIPT_BRANCH="master"
+readonly SCRIPT_VERSION="v1.0.1"
+SCRIPT_BRANCH="develop"
 SCRIPT_REPO="https://raw.githubusercontent.com/jackyaz/$SCRIPT_NAME/$SCRIPT_BRANCH"
 readonly SCRIPT_DIR="/jffs/addons/$SCRIPT_NAME.d"
 readonly SCRIPT_CONF="$SCRIPT_DIR/DHCP_clients"

--- a/YazDHCP.sh
+++ b/YazDHCP.sh
@@ -16,7 +16,7 @@
 ### Start of script variables ###
 readonly SCRIPT_NAME="YazDHCP"
 readonly SCRIPT_VERSION="v1.0.1"
-SCRIPT_BRANCH="develop"
+SCRIPT_BRANCH="master"
 SCRIPT_REPO="https://raw.githubusercontent.com/jackyaz/$SCRIPT_NAME/$SCRIPT_BRANCH"
 readonly SCRIPT_DIR="/jffs/addons/$SCRIPT_NAME.d"
 readonly SCRIPT_CONF="$SCRIPT_DIR/DHCP_clients"

--- a/YazDHCP.sh
+++ b/YazDHCP.sh
@@ -149,7 +149,7 @@ Conf_FromSettings(){
 			Update_Staticlist
 			Update_Optionslist
 			
-			Print_Output true "Merge of updated DHCP information from WebUI completed successfully" "$PASS"
+			Print_Output true "Merge of updated DHCP client information from WebUI completed successfully" "$PASS"
 		else
 			Print_Output false "No updated DHCP information from WebUI found, no merge into $SCRIPT_CONF necessary" "$PASS"
 		fi


### PR DESCRIPTION
NEW: Export DHCP_Clients as a CSV file from the WebUI
NEW: Import DHCP_Clients.csv, e.g. from a backup*
FIXED: Check for updates in WebUI




*The import is intended to be used to import an untouched copy of the exported file. If you decide to edit the exported file, then please ensure you add the appropriate number of delimiters/"columns" if adding any new entries. I do not intend to add any validation to the import file at this time given the intended use. I may add validation in the future if this feature proves popular/people want to safely edit the CSV.