### PR TITLE
v1.0.3

### DIFF
--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -1,0 +1,12 @@
+on: push
+
+name: 'ShellCheck'
+
+jobs:
+  shellcheck:
+    name: Shellcheck
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Run ShellCheck
+      uses: ludeeus/action-shellcheck@master

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,0 @@
-language: shell
-script:
-  - bash -c 'shopt -s globstar; shellcheck YazDHCP.sh'

--- a/Advanced_DHCP_Content.asp
+++ b/Advanced_DHCP_Content.asp
@@ -168,14 +168,18 @@ function ParseCSVData(data){
 	var csvContent = "MAC,IP,HOSTNAME,DNS\n";
 	var settingslength = 0;
 	for(var i = 0; i < data.length; i++){
+		var ipvalue = data[i].IP;
+		if(document.form.lan_netmask.value == "255.255.255.0"){
+			ipvalue = data[i].IP.split(".")[3]
+		}
 		if(data[i].DNS.length > 0 && data[i].HOSTNAME.length >= 0){
-			settingslength+=(data[i].MAC+">"+data[i].IP.split(".")[3]+">"+data[i].HOSTNAME+">"+data[i].DNS+">").length;
+			settingslength+=(data[i].MAC+">"+ipvalue+">"+data[i].HOSTNAME+">"+data[i].DNS+">").length;
 		}
 		else if(data[i].DNS.length == 0 && data[i].HOSTNAME.length > 0){
-			settingslength+=(data[i].MAC+">"+data[i].IP.split(".")[3]+">"+data[i].HOSTNAME+">").length;
+			settingslength+=(data[i].MAC+">"+ipvalue+">"+data[i].HOSTNAME+">").length;
 		}
 		else{
-			settingslength+=(data[i].MAC+">"+data[i].IP.split(".")[3]+">").length;
+			settingslength+=(data[i].MAC+">"+ipvalue+">").length;
 		}
 		var dataString = data[i].MAC+","+data[i].IP+","+data[i].HOSTNAME+","+data[i].DNS;
 		csvContent += i < data.length-1 ? dataString + '\n' : dataString;
@@ -687,14 +691,19 @@ function applyRule(){
 		dhcp_hostnames_array = [];
 		
 		Object.keys(manually_dhcp_list_array).forEach(function(key){
+			var ipvalue = key;
+			if(document.form.lan_netmask.value == "255.255.255.0"){
+				ipvalue = key.split(".")[3]
+			}
+			
 			if(manually_dhcp_list_array[key].dns.length > 0 && manually_dhcp_list_array[key].hostname.length >= 0){
-				document.form.YazDHCP_clients.value += "<" + manually_dhcp_list_array[key].mac + ">" + key.split(".")[3] + ">" + manually_dhcp_list_array[key].hostname + ">" + manually_dhcp_list_array[key].dns + ">";
+				document.form.YazDHCP_clients.value += "<" + manually_dhcp_list_array[key].mac + ">" + ipvalue + ">" + manually_dhcp_list_array[key].hostname + ">" + manually_dhcp_list_array[key].dns + ">";
 			}
 			else if(manually_dhcp_list_array[key].dns.length == 0 && manually_dhcp_list_array[key].hostname.length > 0){
-				document.form.YazDHCP_clients.value += "<" + manually_dhcp_list_array[key].mac + ">" + key.split(".")[3] + ">" + manually_dhcp_list_array[key].hostname + ">";
+				document.form.YazDHCP_clients.value += "<" + manually_dhcp_list_array[key].mac + ">" + ipvalue + ">" + manually_dhcp_list_array[key].hostname + ">";
 			}
 			else{
-				document.form.YazDHCP_clients.value += "<" + manually_dhcp_list_array[key].mac + ">" + key.split(".")[3] + ">";
+				document.form.YazDHCP_clients.value += "<" + manually_dhcp_list_array[key].mac + ">" + ipvalue + ">";
 			}
 		});
 		

--- a/Advanced_DHCP_Content.asp
+++ b/Advanced_DHCP_Content.asp
@@ -64,7 +64,7 @@ function LoadCustomSettings(){
 	}
 }
 
-$(function (){
+$(function(){
 	if(amesh_support && (isSwMode("rt") || isSwMode("ap")) && ameshRouter_support){
 		addNewScript('/require/modules/amesh.js');
 	}

--- a/Advanced_DHCP_Content.asp
+++ b/Advanced_DHCP_Content.asp
@@ -21,6 +21,22 @@ thead.collapsible-jquery {
   outline: none;
   cursor: pointer;
 }
+.sort_border {
+  position: relative;
+  cursor: pointer;
+}
+.sort_border:before {
+  content: "";
+  position: absolute;
+  width: 100%;
+  left: 0;
+  border-top: 1px solid #FC0;
+  top: 0;
+}
+.sort_border.decrease:before {
+  bottom: 0;
+  top: initial;
+}
 </style>
 <script language="JavaScript" type="text/javascript" src="/ext/shared-jy/jquery.js"></script>
 <script language="JavaScript" type="text/javascript" src="/ext/shared-jy/d3.js"></script>
@@ -244,6 +260,7 @@ function PageSetup(){
 	}
 }
 
+var manually_dhcp_sort_type = 0;//0:increase, 1:decrease
 function initial(){
 	show_menu();
 	document.getElementById("GWStatic").innerHTML = "Manually Assigned IP addresses in the DHCP scope (Max Limit: )" + maxnumrows;
@@ -1075,6 +1092,20 @@ function parse_vpnc_dev_policy_list(_oriNvram){
 		}
 	}
 	return parseArray;
+}
+
+function sortClientIP(){
+	//manually_dhcp_sort_type
+	if($(".sort_border").hasClass("decrease")){
+		$(".sort_border").removeClass("decrease");
+		manually_dhcp_sort_type = 0;
+	}
+	else{
+		$(".sort_border").addClass("decrease");
+		manually_dhcp_sort_type = 1;
+	}
+	
+	showdhcp_staticlist();
 }
 </script>
 </head>

--- a/README.md
+++ b/README.md
@@ -53,12 +53,4 @@ dhcp-hostsfile contains a list of MAC address to IP address bindings, to reserve
 dhcp-optsfile contains a list of MAC address to DNS server address bindings, to provide the specified DNS server as a DHCP option for a MAC address
 
 ## Help
-Please post about any issues and problems here: [YazDHCP on SNBForums](https://www.snbforums.com/threads/yazdhcp-feature-expansion-of-dhcp-assignments-increasing-limit-on-the-number-of-dhcp-reservations.69247/)
-
-## FAQs
-### I haven't used scripts before on AsusWRT-Merlin
-If this is the first time you are using scripts, don't panic! In your router's WebUI, go to the Administration area of the left menu, and then the System tab. Set Enable JFFS custom scripts and configs to Yes.
-
-Further reading about scripts is available here: [AsusWRT-Merlin User-scripts](https://github.com/RMerl/asuswrt-merlin/wiki/User-scripts)
-
-![WebUI enable scripts](https://puu.sh/A3wnG/00a43283ed.png)
+Please post about any issues and problems here: [YazDHCP on SNBForums](https://www.snbforums.com/forums/asuswrt-merlin-addons.60/?prefix_id=31)

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ![Shellcheck](https://github.com/jackyaz/YazDHCP/actions/workflows/shellcheck.yml/badge.svg)
 
 ## v1.0.3
-### Updated on 2021-08-06
+### Updated on 2021-12-23
 ## About
 Feature expansion of DHCP assignments using AsusWRT-Merlin's [Addons API](https://github.com/RMerl/asuswrt-merlin.ng/wiki/Addons-API) to read and write DHCP assignments, increasing the limit on the number of reservations.
 

--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 [![Codacy Badge](https://app.codacy.com/project/badge/Grade/1f193c7b92a34b60bc1ef9a647f04908)](https://www.codacy.com/gh/jackyaz/YazDHCP/dashboard?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=jackyaz/YazDHCP&amp;utm_campaign=Badge_Grade)
 [![Build Status](https://travis-ci.com/jackyaz/YazDHCP.svg?branch=master)](https://travis-ci.com/jackyaz/YazDHCP)
 
-## v1.0.2
-### Updated on 2021-02-27
+## v1.0.3
+### Updated on 2021-06-02
 ## About
 Feature expansion of DHCP assignments using AsusWRT-Merlin's [Addons API](https://github.com/RMerl/asuswrt-merlin.ng/wiki/Addons-API) to read and write DHCP assignments, increasing the limit on the number of reservations.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # YazDHCP
 [![Codacy Badge](https://app.codacy.com/project/badge/Grade/1f193c7b92a34b60bc1ef9a647f04908)](https://www.codacy.com/gh/jackyaz/YazDHCP/dashboard?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=jackyaz/YazDHCP&amp;utm_campaign=Badge_Grade)
-[![Build Status](https://travis-ci.com/jackyaz/YazDHCP.svg?branch=master)](https://travis-ci.com/jackyaz/YazDHCP)
+![Shellcheck](https://github.com/jackyaz/YazDHCP/actions/workflows/shellcheck.yml/badge.svg)
 
 ## v1.0.3
 ### Updated on 2021-06-02

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ![Shellcheck](https://github.com/jackyaz/YazDHCP/actions/workflows/shellcheck.yml/badge.svg)
 
 ## v1.0.3
-### Updated on 2021-06-02
+### Updated on 2021-08-06
 ## About
 Feature expansion of DHCP assignments using AsusWRT-Merlin's [Addons API](https://github.com/RMerl/asuswrt-merlin.ng/wiki/Addons-API) to read and write DHCP assignments, increasing the limit on the number of reservations.
 

--- a/YazDHCP.sh
+++ b/YazDHCP.sh
@@ -13,6 +13,8 @@
 ##                                                      ##
 ##########################################################
 
+# shellcheck disable=SC2155
+
 ### Start of script variables ###
 readonly SCRIPT_NAME="YazDHCP"
 readonly SCRIPT_VERSION="v1.0.3"

--- a/YazDHCP.sh
+++ b/YazDHCP.sh
@@ -481,7 +481,6 @@ Download_File(){
 
 Mount_WebUI(){
 	umount /www/Advanced_DHCP_Content.asp 2>/dev/null
-	
 	mount -o bind "$SCRIPT_DIR/Advanced_DHCP_Content.asp" /www/Advanced_DHCP_Content.asp
 }
 
@@ -821,6 +820,8 @@ Menu_Install(){
 	Auto_ServiceEvent create 2>/dev/null
 	Auto_DNSMASQ create 2>/dev/null
 	Shortcut_Script create
+	
+	echo "MAC,IP,HOSTNAME,DNS" > "$SCRIPT_CONF"
 	
 	Export_FW_DHCP_JFFS
 	

--- a/YazDHCP.sh
+++ b/YazDHCP.sh
@@ -157,7 +157,7 @@ Conf_FromSettings(){
 }
 
 Set_Version_Custom_Settings(){
-	SETTINGSFILE=/jffs/addons/custom_settings.txt
+	SETTINGSFILE="/jffs/addons/custom_settings.txt"
 	case "$1" in
 		local)
 			if [ -f "$SETTINGSFILE" ]; then

--- a/YazDHCP.sh
+++ b/YazDHCP.sh
@@ -124,7 +124,7 @@ Conf_FromSettings(){
 			while IFS='' read -r line || [ -n "$line" ]; do
 				if [ "$(echo "$line" | wc -w)" -eq 4 ]; then
 					echo "$line" | awk '{ print ""$1","$2","$3","$4""; }' >> "$SCRIPT_CONF"
-				else
+				elif [ "$(echo "$line" | wc -w)" -gt 1 ]; then
 					if [ "$(echo "$line" | cut -d " " -f3 | wc -L)" -eq 0 ]; then
 						echo "$line" | awk '{ print ""$1","$2","","$3""; }' >> "$SCRIPT_CONF"
 					else

--- a/YazDHCP.sh
+++ b/YazDHCP.sh
@@ -18,7 +18,7 @@
 ### Start of script variables ###
 readonly SCRIPT_NAME="YazDHCP"
 readonly SCRIPT_VERSION="v1.0.3"
-SCRIPT_BRANCH="develop"
+SCRIPT_BRANCH="master"
 SCRIPT_REPO="https://raw.githubusercontent.com/jackyaz/$SCRIPT_NAME/$SCRIPT_BRANCH"
 readonly SCRIPT_DIR="/jffs/addons/$SCRIPT_NAME.d"
 readonly SCRIPT_CONF="$SCRIPT_DIR/DHCP_clients"

--- a/YazDHCP.sh
+++ b/YazDHCP.sh
@@ -136,7 +136,12 @@ Conf_FromSettings(){
 			done < /tmp/yazdhcp_clients_parsed.tmp
 			
 			LANSUBNET="$(nvram get lan_ipaddr | cut -d'.' -f1-3)"
-			awk -F "," -v lansub="$LANSUBNET" 'FNR==1{print $0; next} BEGIN {OFS = ","} $2=lansub"."$2' "$SCRIPT_CONF" > "$SCRIPT_CONF.tmp"
+			LANNETMASK="$(nvram get lan_netmask)"
+			if [ "$LANNETMASK" = "255.255.255.0" ]; then
+				awk -F "," -v lansub="$LANSUBNET" 'FNR==1{print $0; next} BEGIN {OFS = ","} $2=lansub"."$2' "$SCRIPT_CONF" > "$SCRIPT_CONF.tmp"
+			else
+				cp "$SCRIPT_CONF" "$SCRIPT_CONF.tmp"
+			fi
 			sort -t . -k 3,3n -k 4,4n "$SCRIPT_CONF.tmp" > "$SCRIPT_CONF"
 			rm -f "$SCRIPT_CONF.tmp"
 			

--- a/YazDHCP.sh
+++ b/YazDHCP.sh
@@ -15,8 +15,8 @@
 
 ### Start of script variables ###
 readonly SCRIPT_NAME="YazDHCP"
-readonly SCRIPT_VERSION="v1.0.2"
-SCRIPT_BRANCH="master"
+readonly SCRIPT_VERSION="v1.0.3"
+SCRIPT_BRANCH="develop"
 SCRIPT_REPO="https://raw.githubusercontent.com/jackyaz/$SCRIPT_NAME/$SCRIPT_BRANCH"
 readonly SCRIPT_DIR="/jffs/addons/$SCRIPT_NAME.d"
 readonly SCRIPT_CONF="$SCRIPT_DIR/DHCP_clients"


### PR DESCRIPTION
IMPROVED: YazDHCP now works with subnets other than 255.255.255.0
FIXED: YazDHCP will now work from a fresh install with no existing DHCP assignments to export