### PR TITLE
Remove some checks to make VLAN's work 

### DIFF
--- a/Advanced_DHCP_Content.asp
+++ b/Advanced_DHCP_Content.asp
@@ -169,9 +169,12 @@ function ParseCSVData(data){
 	var settingslength = 0;
 	for(var i = 0; i < data.length; i++){
 		var ipvalue = data[i].IP;
+		/*
+		Remove uneeded check, just use full IP always
 		if(document.form.lan_netmask.value == "255.255.255.0"){
 			ipvalue = data[i].IP.split(".")[3]
 		}
+		*/
 		if(data[i].DNS.length > 0 && data[i].HOSTNAME.length >= 0){
 			settingslength+=(data[i].MAC+">"+ipvalue+">"+data[i].HOSTNAME+">"+data[i].DNS+">").length;
 		}
@@ -692,10 +695,13 @@ function applyRule(){
 		
 		Object.keys(manually_dhcp_list_array).forEach(function(key){
 			var ipvalue = key;
+			/* 
+			REMOVE UNEEDED CHECK, JUST USE FULL IP ALWAYS
 			if(document.form.lan_netmask.value == "255.255.255.0"){
 				ipvalue = key.split(".")[3]
 			}
-			
+			*/ 
+
 			if(manually_dhcp_list_array[key].dns.length > 0 && manually_dhcp_list_array[key].hostname.length >= 0){
 				document.form.YazDHCP_clients.value += "<" + manually_dhcp_list_array[key].mac + ">" + ipvalue + ">" + manually_dhcp_list_array[key].hostname + ">" + manually_dhcp_list_array[key].dns + ">";
 			}
@@ -806,6 +812,8 @@ function validate_dhcp_range(ip_obj){
 		return 0;
 	}
 	
+	/*
+	REMOVE CHECK THAT PREVENTS MOD WORKING
 	subnet_head = getSubnet(document.form.lan_ipaddr.value, document.form.lan_netmask.value, "head");
 	subnet_end = getSubnet(document.form.lan_ipaddr.value, document.form.lan_netmask.value, "end");
 	
@@ -816,6 +824,7 @@ function validate_dhcp_range(ip_obj){
 		ip_obj.select();
 		return 0;
 	}
+	*/
 	
 	return 1;
 }

--- a/YazDHCP.sh
+++ b/YazDHCP.sh
@@ -17,7 +17,7 @@
 
 ### Start of script variables ###
 readonly SCRIPT_NAME="YazDHCP"
-readonly SCRIPT_VERSION="v1.0.4"
+readonly SCRIPT_VERSION="v1.0.5"
 SCRIPT_BRANCH="master"
 SCRIPT_REPO="https://jackyaz.io/$SCRIPT_NAME/$SCRIPT_BRANCH"
 readonly SCRIPT_DIR="/jffs/addons/$SCRIPT_NAME.d"
@@ -142,12 +142,17 @@ Conf_FromSettings(){
 			done < /tmp/yazdhcp_clients_parsed.tmp
 			
 			LANSUBNET="$(nvram get lan_ipaddr | cut -d'.' -f1-3)"
-			LANNETMASK="$(nvram get lan_netmask)"
-			if [ "$LANNETMASK" = "255.255.255.0" ]; then
-				awk -F "," -v lansub="$LANSUBNET" 'FNR==1{print $0; next} BEGIN {OFS = ","} $2=lansub"."$2' "$SCRIPT_CONF" > "$SCRIPT_CONF.tmp"
-			else
-				cp "$SCRIPT_CONF" "$SCRIPT_CONF.tmp"
-			fi
+
+			# Remove uneeded check, just use full IP always
+			# LANNETMASK="$(nvram get lan_netmask)"
+			# if [ "$LANNETMASK" = "255.255.255.0" ]; then
+			# 	awk -F "," -v lansub="$LANSUBNET" 'FNR==1{print $0; next} BEGIN {OFS = ","} $2=lansub"."$2' "$SCRIPT_CONF" > "$SCRIPT_CONF.tmp"
+			# else
+			# 	cp "$SCRIPT_CONF" "$SCRIPT_CONF.tmp"
+			# fi
+		
+			awk -F "," -v lansub="$LANSUBNET" 'FNR==1{print $0; next} BEGIN {OFS = ","} $2=$2' "$SCRIPT_CONF" > "$SCRIPT_CONF.tmp"
+
 			sort -t . -k 3,3n -k 4,4n "$SCRIPT_CONF.tmp" > "$SCRIPT_CONF"
 			rm -f "$SCRIPT_CONF.tmp"
 			


### PR DESCRIPTION
This can be a good start to get multiple subnets/ip ranges working.

It does technically allow people to put invalid IP's in but i think perhaps a checkbox could be added or something?

This is used by myself in conjunction with https://github.com/Fma965/ASUS-DSL-AC68U-VLAN for VLAN support on the DSL-AC68U

I'm not really expecting you to merge this as is, but it's here if you wanted it,i'll keep my non Scarf interfaced version on https://github.com/Fma965/YazDHCP anyway