### PR TITLE
Update YazDHCP.sh

### DIFF
--- a/YazDHCP.sh
+++ b/YazDHCP.sh
@@ -12,7 +12,7 @@
 ##         https://github.com/jackyaz/YazDHCP/          ##
 ##                                                      ##
 ##########################################################
-# Last Modified: Martinski W. [2023-May-29].
+# Last Modified: Martinski W. [2023-May-31].
 #---------------------------------------------------------
 
 #############################################
@@ -462,7 +462,7 @@ Check_CustomUserIconsConfig()
 }
 
 ##----------------------------------------##
-## Modified by Martinski W. [2023-May-28] ##
+## Modified by Martinski W. [2023-May-31] ##
 ##----------------------------------------##
 Conf_FromSettings()
 {
@@ -535,7 +535,8 @@ Conf_FromSettings()
 			if "$RESTART_DNSMASQ"
 			then
 				Print_Output true "Restarting dnsmasq for new DHCP settings to take effect." "$PASS"
-				sleep 1 ; service restart_dnsmasq >/dev/null 2>&1
+				## Delay restarting dnsmasq until the one from WebGUI is completed ##
+				(sleep 2 ; service restart_dnsmasq >/dev/null 2>&1) &
 			fi
 		else
 			Print_Output false "No updated DHCP information from WebUI found, no merge into $SCRIPT_CONF necessary" "$PASS"
@@ -1693,7 +1694,7 @@ RestoreUserIconFiles()
 }
 
 ##----------------------------------------------##
-## Added/Modified by Martinski W. [2023-May-28] ##
+## Added/Modified by Martinski W. [2023-May-31] ##
 ##----------------------------------------------##
 CheckAgainstNVRAMvar()
 {
@@ -1710,8 +1711,8 @@ CheckAgainstNVRAMvar()
    IPv4_Addrs="$(echo "$1" | awk -F ' ' '{print $2}')"
    IPv4_RegEx="([0-9]{1,3}\.){3}([0-9]{1,3})"
    MACx_RegEx="([a-fA-F0-9]{2}\:){5}([a-fA-F0-9]{2})"
-   theRegExp1="<${MACx_Addrs}>${IPv4_RegEx}[>](${IPv4_RegEx})?[>][^<]*"
-   theRegExp2="<${MACx_RegEx}>${IPv4_Addrs}[>](${IPv4_RegEx})?[>][^<]*"
+   theRegExp1="<${MACx_Addrs}>${IPv4_RegEx}[^<]*"
+   theRegExp2="<${MACx_RegEx}>${IPv4_Addrs}[^<]*"
    keyEntry=""
 
    if echo "$theKeyVal" | grep -qiE "$theRegExp1"


### PR DESCRIPTION
Added code to fix two issues:

1) When uninstalling YazDHCP, the "Lease Time" NVRAM value was left behind "as is" which can be "invalid" for the standard WebGUI page when the value is greater than 7 days. Now a check is made during uninstallation to make sure the NVRAM value is <=7 days (in seconds).

2) The option to "Export NVRAM settings" was not available after YazDHCP was installed.
Additional checks are now made to make sure there are no conflicts between the NVRAM entries being exported and any existing DHCP IP assignments already in place. This was done to avoid having "duplicate" MAC or IP addresses in the mix.
