### PR TITLE
Updates to README & YazDHCP.sh script

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ![Shellcheck](https://github.com/jackyaz/YazDHCP/actions/workflows/shellcheck.yml/badge.svg)
 
 ## v1.0.6
-### Updated on 2023-04-23
+### Updated on 2023-06-02
 ## About
 Feature expansion of DHCP assignments using AsusWRT-Merlin's [Addons API](https://github.com/RMerl/asuswrt-merlin.ng/wiki/Addons-API) to read and write DHCP assignments, increasing the limit on the number of reservations.
 
@@ -55,7 +55,15 @@ dhcp-optsfile contains a list of MAC address to DNS server address bindings, to 
 The "DHCP Lease" input field has been enhanced to accept a maximum value of 7776000 seconds (90 days). Values can be entered in seconds (e.g. 86400s), minutes (e.g. 1440m), hours (e.g. 24h), days (e.g. 2d), or weeks (e.g. 2w). A single digit ZERO '0' or an upper-case letter 'I' indicates that an "infinite" lease time value will be applied.
 
 ## "Back up & Restore" custom user icons
-You can save a backup of the custom user icons found in the "/jffs/usericons" directory, and you can later select one of the backup files to restore the icons files as needed. The command line interface allows you to change the directory path where the backup subdirectory is located, and you have option to delete backup files, or list the contents of a backup file. The default maximum number of backup files to keep is 20, but you can change this maximum setting (between min=5 to max=50).
+You can save a backup of the custom user icons found in the "/jffs/usericons" directory, and you can later select one of the backup files to restore the icons files as needed. The command line interface allows you to change the directory path where the backup subdirectory is located, and you have option to delete backup files, or list the contents of a backup file. The default maximum number of backup files to keep is 20, but you can change this maximum setting (between min=5 to max=50) using the CLI menu.
+
+### NOTES:
+
+1) The current implementation of the "Back up & Restore" of custom user icons does *NOT* export to or import from an external PC or client device connected to the router. Instead, it targets a directory available either on the router's JFFS partition or in a USB-attached disk drive. This target directory is where the subdirectory for backups is created and can be modified using the CLI menu (see note #3 below).
+
+2) The CLI main menu option 2 for the "Back up & Restore" functionality will show up only if there is at least one custom user icon file found in the "/jffs/usericon" directory, or if at least one backup file is found in the directory path defined for backups. If none of those 2 conditions is met, the option 2 will not show up in the main menu.
+
+3) To start using the "Back up & Restore custom user icons" feature, it's highly recommended to set the target directory where the subdirectory for backups is to be located (see option "dp" in the CLI menu). For the backups subdirectory to survive a "Factory Defaults Reset" of the router, it's highly recommended to use a directory path located on a disk drive plugged in to one of the router's USB ports. You don't have to have Entware installed on the USB-attached disk; any USB disk drive formatted with either NTFS or ext4 is sufficient to use as storage for the backup files.
 
 ## Help
 Please post about any issues and problems here: [YazDHCP on SNBForums](https://www.snbforums.com/forums/asuswrt-merlin-addons.60/?prefix_id=31)

--- a/YazDHCP.sh
+++ b/YazDHCP.sh
@@ -12,7 +12,7 @@
 ##         https://github.com/jackyaz/YazDHCP/          ##
 ##                                                      ##
 ##########################################################
-# Last Modified: Martinski W. [2023-May-31].
+# Last Modified: Martinski W. [2023-Jun-02].
 #---------------------------------------------------------
 
 #############################################
@@ -1694,7 +1694,7 @@ RestoreUserIconFiles()
 }
 
 ##----------------------------------------------##
-## Added/Modified by Martinski W. [2023-May-31] ##
+## Added/Modified by Martinski W. [2023-Jun-02] ##
 ##----------------------------------------------##
 CheckAgainstNVRAMvar()
 {
@@ -1711,8 +1711,8 @@ CheckAgainstNVRAMvar()
    IPv4_Addrs="$(echo "$1" | awk -F ' ' '{print $2}')"
    IPv4_RegEx="([0-9]{1,3}\.){3}([0-9]{1,3})"
    MACx_RegEx="([a-fA-F0-9]{2}\:){5}([a-fA-F0-9]{2})"
-   theRegExp1="<${MACx_Addrs}>${IPv4_RegEx}[^<]*"
-   theRegExp2="<${MACx_RegEx}>${IPv4_Addrs}[^<]*"
+   theRegExp1="<${MACx_Addrs}>${IPv4_RegEx}>[^<]*"
+   theRegExp2="<${MACx_RegEx}>${IPv4_Addrs}>[^<]*"
    keyEntry=""
 
    if echo "$theKeyVal" | grep -qiE "$theRegExp1"


### PR DESCRIPTION
- One more improvement to RegExp string used to parse "dhcp_staticlist" NVRAM variable when building the "DHCP_clients" file.

- Added brief notes to clarify some of the functionality of the "Back up & Restore" feature.
