### PR TITLE
Update Advanced_DHCP_Content.asp

### DIFF
--- a/Advanced_DHCP_Content.asp
+++ b/Advanced_DHCP_Content.asp
@@ -57,7 +57,7 @@ thead.collapsible-jquery {
 <script>
 
 /**---------------------------------------------**/
-/** Last Modified by Martinski W. [2023-Apr-24] **/
+/** Last Modified by Martinski W. [2023-Jun-14] **/
 /**---------------------------------------------**/
 
 const actionScriptPrefix="start_YazDHCP";
@@ -420,6 +420,12 @@ var backup_dns = "";
 var backup_name = "";
 var sortfield, sortdir;
 var sorted_array = [];
+
+/**---------------------------------------**/
+/** Ported by Martinski W. [2023-Jun-13]  **/
+/** For IPv6 DNS support (from 388.X ASP) **/
+/**---------------------------------------**/
+var ipv6_proto_orig = httpApi.nvramGet(["ipv6_service"]).ipv6_service;
 
 function SelectedFile(){
 	var fileList = event.target.files;
@@ -1055,7 +1061,7 @@ function Get_DHCP_LeaseConfig()
 var manually_dhcp_sort_type = 0;//0:increase, 1:decrease
 
 /**----------------------------------------**/
-/** Modified by Martinski W. [2023-Apr-22] **/
+/** Modified by Martinski W. [2023-Jun-14] **/
 /**----------------------------------------**/
 function initial(){
 	show_menu();
@@ -1084,7 +1090,23 @@ function initial(){
 	
 	document.form.sip_server.disabled = true;
 	document.form.sip_server.parentNode.parentNode.style.display = "none";
-	
+
+	/**---------------------------------------**/
+	/** Ported by Martinski W. [2023-Jun-14]  **/
+	/** For IPv6 DNS support (from 388.X ASP) **/
+	/**---------------------------------------**/
+	if (typeof IPv6_support != 'undefined' && IPv6_support != null &&
+	    IPv6_support && ipv6_proto_orig != "disabled")
+	{
+		document.form.ipv6_dns1_x.disabled = false;
+		document.form.ipv6_dns1_x.parentNode.parentNode.style.display = "";
+	}
+	else
+	{
+		document.form.ipv6_dns1_x.disabled = true;
+		document.form.ipv6_dns1_x.parentNode.parentNode.style.display = "none";
+	}
+
 	if(vpn_fusion_support){
 		vpnc_dev_policy_list_array = parse_vpnc_dev_policy_list('<% nvram_char_to_ascii("","vpnc_dev_policy_list"); %>');
 		vpnc_dev_policy_list_array_ori = vpnc_dev_policy_list_array.slice();
@@ -1625,6 +1647,9 @@ function validate_dhcp_range(ip_obj){
 	return 1;
 }
 
+/**----------------------------------------**/
+/** Modified by Martinski W. [2023-Jun-14] **/
+/**----------------------------------------**/
 function validForm(){
 	var re = new RegExp('^[a-zA-Z0-9][a-zA-Z0-9\.\-]*[a-zA-Z0-9]$','gi');
 	if((!re.test(document.form.lan_domain.value) || document.form.lan_domain.value.indexOf("asuscomm.com") > 0) && document.form.lan_domain.value != ""){
@@ -1680,6 +1705,17 @@ function validForm(){
 	//Filtering ip address with leading zero
 	document.form.dhcp_start.value = ipFilterZero(document.form.dhcp_start.value);
 	document.form.dhcp_end.value = ipFilterZero(document.form.dhcp_end.value);
+
+	/**---------------------------------------**/
+	/** Ported by Martinski W. [2023-Jun-14]  **/
+	/** For IPv6 DNS support (from 388.X ASP) **/
+	/**---------------------------------------**/
+	if (typeof IPv6_support != 'undefined' && IPv6_support != null &&
+	    IPv6_support && ipv6_proto_orig != "disabled")
+	{
+		if (document.form.ipv6_dns1_x.value != "")
+		{ if (!validator.isLegal_ipv6(document.form.ipv6_dns1_x)) return false; }
+	}
 	return true;
 }
 
@@ -2109,6 +2145,19 @@ function sortClientIP(){
 <td>
 <input type="radio" value="1" name="dhcpd_dns_router" class="content_input_fd" onclick="return change_common_radio(this, 'LANHostConfig', 'dhcpd_dns_router', '1')" <% nvram_match("dhcpd_dns_router", "1", "checked"); %>>Yes
 <input type="radio" value="0" name="dhcpd_dns_router" class="content_input_fd" onclick="return change_common_radio(this, 'LANHostConfig', 'dhcpd_dns_router', '0')" <% nvram_match("dhcpd_dns_router", "0", "checked"); %>>No
+</td>
+</tr>
+
+<!--
+**---------------------------------------**
+** Ported by Martinski W. [2023-Jun-13]  **
+** For IPv6 DNS support (from 388.X ASP) **
+**---------------------------------------**
+-->
+<tr style="display:none;">
+<th width="200">IPv6 DNS Server</th>
+<td>
+<input type="text" maxlength="39" class="input_32_table" name="ipv6_dns1_x" value="<% nvram_get("ipv6_dns1_x"); %>" autocorrect="off" autocapitalize="off">
 </td>
 </tr>
 


### PR DESCRIPTION
Ported code from a 388.x F/W ASP file to enable support of the "IPv6 DNS Server" option that should have become visible when IPv6 is enabled on the router (see IPv6 webGUI tab). The issue was reported on the SNBForums "Asuswrt-Merlin AddOns" section.

